### PR TITLE
Fix iounits

### DIFF
--- a/ipi/engine/initializer.py
+++ b/ipi/engine/initializer.py
@@ -321,7 +321,6 @@ class Initializer(dobject):
             else:
                rh =  init_file(v.mode,v.value)[1].h
 
-
             if fcell :
                warning("Overwriting previous cell parameters", verbosity.low)
 
@@ -391,9 +390,11 @@ class Initializer(dobject):
             rq = init_vector(v, self.nbeads)
 
             if len(v.units) > 0 and v.units != 'atomic_unit':
-               warning("If the units of position are already specified into the"
-                       " pdb or xyz file, the conversion will be applied twice "
-                       "with unpredictable results!!", verbosity.low)
+               warning("If the position units are already specified into the pdb "
+                       "or xyz file, the conversion will be applied twice with "
+                       "unpredictable results!!\nThis attribute is also "
+                       "deprecated and will be removed in the following "
+                       "version.", verbosity.low)
 
             rq *= unit_to_internal("length",v.units,1.0)
             nbeads, natoms = rq.shape

--- a/ipi/engine/initializer.py
+++ b/ipi/engine/initializer.py
@@ -1,3 +1,4 @@
+# pylint: disable=bad-indentation
 """Contains the classes that are used to initialize data in the simulation.
 
 These classes can either be used to restart a simulation with some different
@@ -308,14 +309,30 @@ class Initializer(dobject):
          info(" # Initializer (stage 1) parsing " + str(k) + " object.", verbosity.high)
 
          if k == "cell":
-            if fcell :
-               warning("Overwriting previous cell parameters", verbosity.medium)
             if v.mode == "manual":
                 rh = v.value.reshape((3,3))
             elif v.mode == "chk":
                rh = init_chk(v.value)[1].h
+            elif init_file(v.mode,v.value)[1].h.trace() == -3:
+               # In case the file do not contain any
+               #+ cell parameters, the diagonal elements of the cell will be
+               #+set to -1 from the io_units and nothing is read here.
+               continue
             else:
-               rh = init_file(v.mode,v.value)[1].h
+               rh =  init_file(v.mode,v.value)[1].h
+
+
+            if fcell :
+               warning("Overwriting previous cell parameters", verbosity.low)
+
+
+            if len(v.units) > 0 and v.units != 'atomic_unit':
+               warning("If the cell units are already specified into the pdb "
+                       "or xyz file, the conversion will be applied twice with "
+                       "unpredictable results!!\nThis attribute is also "
+                       "deprecated and will be removed in the following "
+                       "version.", verbosity.low)
+
             rh *= unit_to_internal("length",v.units,1.0)
 
             simul.cell.h = rh
@@ -372,6 +389,12 @@ class Initializer(dobject):
                warning("Overwriting previous atomic positions", verbosity.medium)
             # read the atomic positions as a vector
             rq = init_vector(v, self.nbeads)
+
+            if len(v.units) > 0 and v.units != 'atomic_unit':
+               warning("If the units of position are already specified into the"
+                       " pdb or xyz file, the conversion will be applied twice "
+                       "with unpredictable results!!", verbosity.low)
+
             rq *= unit_to_internal("length",v.units,1.0)
             nbeads, natoms = rq.shape
             natoms /= 3

--- a/ipi/engine/properties.py
+++ b/ipi/engine/properties.py
@@ -1960,7 +1960,7 @@ class Trajectories(dobject):
       fcell = Cell()
       fcell.h = self.system.cell.h*unit_to_user("length", cell_units, 1.0)
 
-      io.print_file(format, fatom, fcell, stream, title=("{%s}  Traj: %s Step:  %10d  Bead:   %5d " % (cell_units, what, self.system.simul.step+1, b) ) )
+      io.print_file(format, fatom, fcell, stream, title=("cell{%s}  Traj: %s Step:  %10d  Bead:   %5d " % (cell_units, what, self.system.simul.step+1, b) ) )
       if flush :
          stream.flush()
          os.fsync(stream)

--- a/ipi/inputs/initializer.py
+++ b/ipi/inputs/initializer.py
@@ -367,7 +367,7 @@ class InputInitializer(Input):
                rm.units = ""
                initlist.append( ( "masses",   rm ) )
                initlist.append( ( "labels",   v.fetch(initclass=ei.InitIndexed) ) )
-            if mode == "pdb" or mode == "chk":
+#            if mode == "pdb" or mode == "chk":
                initlist.append( ( "cell", v.fetch(initclass=ei.InitIndexed) ) )
             if mode == "chk":
                rm = v.fetch(initclass=ei.InitIndexed)

--- a/ipi/utils/io/backends/io_pdb.py
+++ b/ipi/utils/io/backends/io_pdb.py
@@ -34,7 +34,7 @@ def print_pdb_path(beads, cell, filedesc=sys.stdout):
     """
 
     fmt_cryst = "CRYST1%9.3f%9.3f%9.3f%7.2f%7.2f%7.2f%s%4i\n"
-    fmt_atom = "ATOM  %5i %4s%1s%3s %1s%4i%1s   %8.3f%8.3f%8.3f%6.2f%6.2f          %2s%2i\n"
+    fmt_atom = "ATOM  %5i %4s%1s%3s %1s%4i%1s  %8.3f%8.3f%8.3f%6.2f%6.2f          %2s%2i\n"
     fmt_conect = "CONECT%5i%5i\n"
 
     a, b, c, alpha, beta, gamma = mt.h2abc_deg(cell.h)
@@ -76,8 +76,7 @@ def print_pdb(atoms, cell, filedesc=sys.stdout, title=""):
     """
 
     fmt_cryst = "CRYST1%9.3f%9.3f%9.3f%7.2f%7.2f%7.2f%s%4i\n"
-    fmt_atom = "ATOM  %5i %4s%1s%3s %1s%4i%1s    %8.3f%8.3f%8.3f%6.2f%6.2f          %2s%2i\n"
-
+    fmt_atom = "ATOM  %5i %4s%1s%3s %1s%4i%1s   %8.3f%8.3f%8.3f%6.2f%6.2f          %2s%2i\n"
 
     if title != "":
         filedesc.write("TITLE   %70s\n" % (title))

--- a/ipi/utils/io/backends/io_units.py
+++ b/ipi/utils/io/backends/io_units.py
@@ -13,15 +13,15 @@ from ipi.utils.units import unit_to_internal
 from ipi.engine.properties import Trajectories as Traj
 
 # Regular expressions initialization for read_xyz function
-cell_unit_re = re.compile(r'\s\{[a-z]*\}\s')             # cell unit pattern
-traj_dict = Traj().traj_dict                            # trajectory dictionary
+cell_unit_re = re.compile(r'cell\{([a-z]*)\}')             # cell unit pattern
+traj_dict = Traj().traj_dict                             # trajectory dictionary
 traj_re = [re.compile('%s%s' % (key, r'\{[a-z]*\}'))
            for key in traj_dict.keys()]  # trajectory patterns
 
 def process_units(comment, cell, qatoms, names, masses, output='objects'):
     """ Converts the data in the file according to the units written in the ipi format.
     """
-
+    import pdb; pdb.set_trace()
     # Extracting trajectory units
     family, unit = 'undefined', ''
     is_comment_useful = filter(None, [key.search(comment.strip())
@@ -34,12 +34,11 @@ def process_units(comment, cell, qatoms, names, masses, output='objects'):
     cell_unit = ''
     tmp = cell_unit_re.search(comment)
     if tmp is not None:
-        cell_unit = tmp.group()[2:-2]
+        cell_unit = tmp.group(1)
 
     # Units transformation
     cell *= unit_to_internal('length', cell_unit, 1) # cell units transformation
     qatoms *= unit_to_internal(family, unit, 1) # units transformation
-
     if output == 'objects':
 
         cell = Cell(cell)

--- a/ipi/utils/io/backends/io_units.py
+++ b/ipi/utils/io/backends/io_units.py
@@ -21,7 +21,6 @@ traj_re = [re.compile('%s%s' % (key, r'\{[a-z]*\}'))
 def process_units(comment, cell, qatoms, names, masses, output='objects'):
     """ Converts the data in the file according to the units written in the ipi format.
     """
-    import pdb; pdb.set_trace()
     # Extracting trajectory units
     family, unit = 'undefined', ''
     is_comment_useful = filter(None, [key.search(comment.strip())

--- a/ipi/utils/io/backends/io_xyz.py
+++ b/ipi/utils/io/backends/io_xyz.py
@@ -73,9 +73,9 @@ def print_xyz(atoms, cell, filedesc=sys.stdout, title=""):
 # TODO: These REGEX would need some revisions
 #+for now ensure the right number of "argument" when reading the array
 
-cell_re = [re.compile('# CELL[\(\[\{]abcABC[\)\]\}]: ([-0-9\.Ee ]*)\s*'),
-           re.compile('# CELL[\(\[\{]GENH[\)\]\}]: ([-0-9\.?Ee ]*)\s*'),
-           re.compile('# CELL[\(\[\{]H[\)\]\}]: ([-0-9\.?Ee ]*)\s*')]
+cell_re = [re.compile('CELL[\(\[\{]abcABC[\)\]\}]: ([-0-9\.Ee ]*)\s*'),
+           re.compile('CELL[\(\[\{]GENH[\)\]\}]: ([-0-9\.?Ee ]*)\s*'),
+           re.compile('CELL[\(\[\{]H[\)\]\}]: ([-0-9\.?Ee ]*)\s*')]
 
 def read_xyz(filedesc, **kwargs):
     """Reads an XYZ-style file with i-PI style comments and returns data in raw format for further units transformation
@@ -119,7 +119,7 @@ def read_xyz(filedesc, **kwargs):
         h = mt.abc2h(*mt.genh2abc(genh))
         usegenh = True
     else:                     # defaults to unit box
-        h = mt.abc2h(1.0, 1.0, 1.0, np.pi/2.0, np.pi/2.0, np.pi/2.0)
+        h = np.array([[-1.0, 0.0, 0.0],[0.0, -1.0, 0.0],[0.0, 0.0, -1.0]])
     cell = h
 
     qatoms = np.zeros(3*natoms)

--- a/ipi_tests/pdb_generator.py
+++ b/ipi_tests/pdb_generator.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python2
+""" Generate fake parameters useful to test the softare.
+"""
+
+import tempfile as tmp
+import numpy as np
+from ipi.utils.units import Elements
+from copy import copy
+all_elem = Elements.mass_list.keys()
+at_names = None
+
+def xyz_rand(natoms, comment, names=None):
+    """ Generate a fake pdb pseudo-file. Atoms and coordinates are random.
+    """
+
+    global at_names
+    xyz = np.random.random((natoms, 3))
+    xyz = (xyz * 10 - 5) # To have both, positive and negative numbers
+    if not names:
+    # if True:
+        at_names = [all_elem[i] for i in
+                    np.random.randint(0, len(all_elem), natoms)]
+
+    if not comment.endswith('\n'):
+        comment += '\n'
+    output = comment
+    for i in xrange(natoms):
+        output += ('%-6s'    # Record name                       1- 6  1
+                   '%5i'    # Atom serial number                7-11  2
+                   ' '      # Space                               12
+                   '%3s'    # Atom name                        13-16  3
+                   ' '      # Alternate location indicator (?)    17
+                   '%3s'    # Residue name                     18-20  4
+                   ' '      # Space                               21
+                   '%1s'    # Chain identifier                    22  5
+                   '%3i'    # Residue sequence number          23-26  6
+                   '%1s'    # Code for insertion of residues(?)   27  7
+                   '   '    # Spacese                          28-30
+                   '%8.3f'  # X coordinate                     31-38  8
+                   '%8.3f'  # Y coordinate                     39-46  9
+                   '%8.3f'  # Z coordinate                     47-54 10
+                   '%6.2f'  # Occupancy                        55-60 11
+                   '%6.2f'  # Temp Factor                      61-66 12
+                   '          ' # space                        67-76
+                   '%3s'    # Element symbol, right-justif     77-78 13
+                   '%3s\n'  # Charge on atom.                  79-80 14
+                   %         ('ATOM', i, at_names[i], 'UNK', ' ', i, ' ', xyz[i, 0], xyz[i, 1], xyz[i, 2], 1.0, 0.0, at_names[i].rjust(3), ' '))
+
+    return (output, xyz.flatten(), copy(at_names))
+
+
+def xyz_traj(natoms, nframe, comment):
+    """ Generate a fake xyz trajectory. Atoms and coordinates are random.
+    """
+    output, xyz, all_names = xyz_rand(natoms, comment)
+    for _ in xrange(nframe - 1):
+        raw_output = xyz_rand(natoms, comment, names=True)
+        output += raw_output[0]
+        xyz = np.concatenate([xyz, raw_output[1]])
+        all_names += raw_output[2]
+
+    return (output, xyz, all_names)
+
+def xyz_traj_filedesc(natoms, nframe, comment):
+    """ Generate a file descriptor containing a fake xyz trajectory.
+    """
+    contents, xyz, all_names = xyz_traj(natoms, nframe, comment)
+    filedesc = tmp.NamedTemporaryFile(mode='wr')
+    filedesc.write(contents)
+    filedesc.seek(0)
+    # This works only on unix!
+    return (open(filedesc.name), xyz, all_names)
+
+if __name__ == '__main__':
+
+    # Fast autocheck... if the test is wrong itself... it is bad ;)
+    natoms = 100
+    print xyz_rand(natoms, '')[0]


### PR DESCRIPTION
Fixing the issue #147 
 - the pdb is printed in the right way and match exactly the xyz. 
 - the cell is initialized even with an xyz file. If the cell is present in the xml too, the last one which is read is used.
 - a warning message is printed when the units for cell and position are specified in the xml file. The standard way should be to specify the units of the cell and the units of the contents directly in the comment line of the xyz  or in the TITLE line of the pdb using the keywords `quantity{units}` and `cell{units}`. The needed of specifying cell and contents units in a different place is necessary since the file contents can be everything, not only "length".

**Check the warning message** they could probably be shorter...

### Still todo:
 - [ ] Update the documentation
 - [ ] Update the examples
 - [ ] Move the output units conversion machinery into the `io` module

@ceriottm  Despite the "Still todo" it would be important to merge this fix.

