### PR TITLE
A simpler syntax for accessing depend objects

### DIFF
--- a/ipi/engine/atoms.py
+++ b/ipi/engine/atoms.py
@@ -131,15 +131,16 @@ class Atoms(dobject):
          dset(self,"m",_prebind[2])
          dset(self,"names",_prebind[3])
 
-      dd(self).m3 = depend_array(name="m3",value=np.zeros(3*natoms, float),
-                                 func=self.mtom3,dependencies=[dd(self).m] )
+      dself = dd(self) # direct access
+      dself.m3 = depend_array(name="m3",value=np.zeros(3*natoms, float),
+                                 func=self.mtom3,dependencies=[dself.m] )
 
-      dd(self).M = depend_value(name="M",func=self.get_msum,
-                   dependencies=[dd(self).m])
-      dd(self).kin = depend_value(name="kin",func=self.get_kin,
-            dependencies=[dd(self).p,dd(self).m3])
-      dd(self).kstress = depend_value(name="kstress",func=self.get_kstress,
-            dependencies=[dd(self).p,dd(self).m])
+      dself.M = depend_value(name="M",func=self.get_msum,
+                   dependencies=[dself.m])
+      dself.kin = depend_value(name="kin",func=self.get_kin,
+            dependencies=[dself.p,dself.m3])
+      dself.kstress = depend_value(name="kstress",func=self.get_kstress,
+            dependencies=[dself.p,dself.m])
 
    def copy(self):
       """Creates a new Atoms object.

--- a/ipi/engine/atoms.py
+++ b/ipi/engine/atoms.py
@@ -131,19 +131,15 @@ class Atoms(dobject):
          dset(self,"m",_prebind[2])
          dset(self,"names",_prebind[3])
 
-      dset(self,"m3",
-         depend_array(name="m3",value=np.zeros(3*natoms, float),func=self.mtom3,
-            dependencies=[dget(self,"m")]))
+      dd(self).m3 = depend_array(name="m3",value=np.zeros(3*natoms, float),
+                                 func=self.mtom3,dependencies=[dd(self).m] )
 
-      dset(self,"M",
-         depend_value(name="M",func=self.get_msum,
-            dependencies=[dget(self,"m")]) )
-      dset(self,"kin",
-         depend_value(name="kin",func=self.get_kin,
-            dependencies=[dget(self,"p"),dget(self,"m3")]) )
-      dset(self,"kstress",
-         depend_value(name="kstress",func=self.get_kstress,
-            dependencies=[dget(self,"p"),dget(self,"m")]) )
+      dd(self).M = depend_value(name="M",func=self.get_msum,
+                   dependencies=[dd(self).m])
+      dd(self).kin = depend_value(name="kin",func=self.get_kin,
+            dependencies=[dd(self).p,dd(self).m3])
+      dd(self).kstress = depend_value(name="kstress",func=self.get_kstress,
+            dependencies=[dd(self).p,dd(self).m])
 
    def copy(self):
       """Creates a new Atoms object.

--- a/ipi/engine/beads.py
+++ b/ipi/engine/beads.py
@@ -89,7 +89,7 @@ class Beads(dobject):
       self.natoms = natoms
       self.nbeads = nbeads
 
-      dself = self.dd
+      dself = dd(self)
       
       dself.names = depend_array(name="names", value=np.zeros(natoms, np.dtype('|S6')))
 
@@ -123,12 +123,12 @@ class Beads(dobject):
       # kinetic energies of thhe beads, and total (classical) kinetic stress tensor
       dself.kins = depend_array(name="kins", value=np.zeros(nbeads, float),
             func=self.kin_gather,
-               dependencies=[b.dd.kin for b in self._blist])
+               dependencies=[dd(b).kin for b in self._blist])
       dself.kin = depend_value(name="kin", func=self.get_kin,
             dependencies=[dself.kins])
       dself.kstress = depend_array(name="kstress",value=np.zeros((3,3), float),
             func=self.get_kstress,
-               dependencies=[b.dd.kstress for b in self._blist])
+               dependencies=[dd(b).kstress for b in self._blist])
 
    def copy(self):
       """Creates a new beads object from the original.

--- a/ipi/engine/cell.py
+++ b/ipi/engine/cell.py
@@ -43,7 +43,7 @@ class Cell(dobject):
       if h is None:
          h = np.zeros((3,3), float)
          
-      dself = self.dd
+      dself = dd(self) # gets a direct-access view to self
 
       dself.h = depend_array(name='h', value=h)
       dself.ih = depend_array(name="ih", value=np.zeros((3,3),float),

--- a/ipi/engine/system.py
+++ b/ipi/engine/system.py
@@ -104,8 +104,8 @@ class System(dobject):
       self.motion.bind(self.ensemble, self.beads, self.nm, self.cell, self.forces, self.prng)
 
          
-      deppipe(self.nm, "omegan2", self.forces, "omegan2")
-
+      dpipe(dd(self.nm).omegan2, dd(self.forces).omegan2)
+      
       self.init.init_stage2(self)
 
       # binds output management objects

--- a/ipi/engine/thermostats.py
+++ b/ipi/engine/thermostats.py
@@ -58,9 +58,10 @@ class Thermostat(dobject):
             initialised from a checkpoint file.
       """
 
-      dset(self,"temp",   depend_value(name='temp', value=temp))
-      dset(self,"dt",     depend_value(name='dt', value=dt))
-      dset(self,"ethermo",depend_value(name='ethermo',value=ethermo))
+      dself = dd(self)  
+      dself.temp = depend_value(name='temp', value=temp)
+      dself.dt = depend_value(name='dt', value=dt)
+      dself.ethermo = depend_value(name='ethermo',value=ethermo)
 
    def bind(self, beads=None, atoms=None, pm=None, nm=None, prng=None, fixdof=None):
       """Binds the appropriate degrees of freedom to the thermostat.
@@ -94,15 +95,16 @@ class Thermostat(dobject):
       else:
          self.prng = prng
 
+      dself = dd(self)
       if not beads is None:
-         dset(self,"p",beads.p.flatten())
-         dset(self,"m",beads.m3.flatten())
+         dself.p = beads.p.flatten()
+         dself.m = beads.m3.flatten()
       elif not atoms is None:
-         dset(self,"p",dget(atoms, "p"))
-         dset(self,"m",dget(atoms, "m3"))
+         dself.p = dd(atoms).p
+         dself.m = dd(atoms).m3
       elif not pm is None:
-         dset(self,"p",pm[0].flatten())  # MR this should allow to simply pass the cell momenta in the anisotropic barostat
-         dset(self,"m",pm[1].flatten())
+         dself.p = pm[0].flatten()  # MR this should allow to simply pass the cell momenta in the anisotropic barostat
+         dself.m = pm[1].flatten()
       else:
          raise TypeError("Thermostat.bind expects either Beads, Atoms, NormalModes, or a (p,m) tuple to bind to")
 
@@ -111,9 +113,8 @@ class Thermostat(dobject):
       else:
          self.ndof = float(len(self.p) - fixdof)
 
-      dset(self, "sm",
-         depend_array(name="sm", value=np.zeros(len(dget(self,"m"))),
-            func=self.get_sm, dependencies=[dget(self,"m")]))
+      dself.sm = depend_array(name="sm", value=np.zeros(len(dself.m)),
+            func=self.get_sm, dependencies=[dself.m])
 
    def get_sm(self):
       """Retrieves the square root of the mass matrix.

--- a/ipi/utils/depend.py
+++ b/ipi/utils/depend.py
@@ -32,7 +32,7 @@ from ipi.utils.messages import verbosity, warning
 
 
 __all__ = ['depend_base', 'depend_value', 'depend_array', 'synchronizer',
-           'dobject', 'dget', 'dset', 'depstrip', 'depcopy', 'deppipe', 'depraise']
+           'dobject', 'dd', 'dget', 'dset', 'depstrip', 'depcopy', 'deppipe', 'depraise']
 
 
 class synchronizer(object):
@@ -772,8 +772,8 @@ class dobject(object):
         __get__() function rather than the standard one.
         """
 
-        value = object.__getattribute__(self, name)
-        if hasattr(value, '__get__'):
+        value = super(dobject,self).__getattribute__(name)
+        if issubclass(value.__class__, depend_base):
             value = value.__get__(self, self.__class__)
         return value
 
@@ -786,15 +786,19 @@ class dobject(object):
         """
 
         try:
-            obj = object.__getattribute__(self, name)
+            obj = super(dobject,self).__getattribute__(name)
         except AttributeError:
             pass
         else:
-            if hasattr(obj, '__set__'):
+            if issubclass(obj.__class__, depend_base):
                 return obj.__set__(self, value)
-        return object.__setattr__(self, name, value)
+        return super(dobject,self).__setattr__(name, value)
 
-
+def dd(dobj):
+    if not issubclass(dobj.__class__, dobject):
+        raise ValueError("Cannot access a ddirect view of an object which is not a subclass of dobject")
+    return dobj.dd
+    
 class ddirect(object):
     """Gives a "view" of a depend object where one can directly access its
     depend_base members."""

--- a/ipi/utils/inputvalue.py
+++ b/ipi/utils/inputvalue.py
@@ -324,10 +324,14 @@ class Input(object):
             elif a == "_text":
                pass
             else:
-               raise NameError("Attribute name '" + a + "' is not a recognized property of '" + xml.name + "' objects")
-
+               raise NameError("Attribute name '" + a + "' is not a recognized property of '" + xml.name + "' objects")            
+          
+         lf = []   
          for (f, v) in xml.fields: #reads all field and dynamic data.
             if f in self.instancefields:
+               if f in lf:                   
+                   raise NameError("The static tag '" + f + "' is defined multiple times within '" + xml.name)
+               lf.append(f)
                self.__dict__[f].parse(xml=v)
             elif f == "_text":
                self._text = v
@@ -345,6 +349,7 @@ class Input(object):
             vf = self.__dict__[f]
             if not (vf._explicit or vf._optional):
                raise ValueError("Field name '" + f + "' is mandatory and was not found in the input for the property " + xml.name)
+                  
 
    def detail_str(self):
       """Prints out the supplementary information about a particular input class.


### PR DESCRIPTION
With input from @OndrejMarsalek and @grhawk I want to propose a simpler (or at least less verbose) syntax to access depend objects and construct the dependent chains. 
If there are no objections, I'd merge but leave the branch active, and slowly convert existing dget/dset syntax to the new one. Also, would be nice to add a few unit tests concerning depend objects, and perhaps a tool to print the full graph of dependencies of an i-PI session.